### PR TITLE
Fix for headings in wrong order

### DIFF
--- a/Exfiltration/Get-Keystrokes.ps1
+++ b/Exfiltration/Get-Keystrokes.ps1
@@ -49,7 +49,7 @@ function Get-Keystrokes {
     $Initilizer = {
         $LogPath = 'REPLACEME'
 
-        '"TypedKey","Time","WindowTitle"' | Out-File -FilePath $LogPath -Encoding unicode
+        '"WindowTitle","TypedKey","Time"' | Out-File -FilePath $LogPath -Encoding unicode
 
         function KeyLog {
             [Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null


### PR DESCRIPTION
The column headings in the log file are out of order, e.g.

```
"TypedKey","Time","WindowTitle"
"Document1 - Word","[Shift]","01-05-2015:20:53:29:28"
"Document1 - Word","[Shift][Shift]","01-05-2015:20:53:29:31"
"Document1 - Word","[Shift]","01-05-2015:20:53:29:38"
```

The "WindowTitle" should be the first column heading like this,

```
"WindowTitle","TypedKey","Time"
"Document1 - Word","[Shift]","01-05-2015:20:53:29:28"
"Document1 - Word","[Shift][Shift]","01-05-2015:20:53:29:31"
"Document1 - Word","[Shift]","01-05-2015:20:53:29:38"
```

Nothing critical :wink: 

Btw awesome project!
